### PR TITLE
Use isMasterRequest method from GetResponseEvent

### DIFF
--- a/EventListener/PinkfireRequestListener.php
+++ b/EventListener/PinkfireRequestListener.php
@@ -7,7 +7,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class PinkfireRequestListener implements EventSubscriberInterface
@@ -21,7 +20,7 @@ class PinkfireRequestListener implements EventSubscriberInterface
 
     public function onKernelRequest(GetResponseEvent $event)
     {
-        if (HttpKernel::MASTER_REQUEST != $event->getRequestType()) {
+        if (!$event->isMasterRequest()) {
             return;
         }
 


### PR DESCRIPTION
The event GetResponseEvent already has a isMasterRequest method that checks if the current request is a master request, use it instead.
